### PR TITLE
Make monkeyYaml Python3 compatible

### DIFF
--- a/src/_monkeyYaml.py
+++ b/src/_monkeyYaml.py
@@ -69,7 +69,7 @@ def myMaybeList(value):
 def myMultilineList(lines, value):
     # assume no explcit indentor (otherwise have to parse value)
     value = []
-    indent = None
+    indent = 0
     while lines:
         line = lines.pop(0)
         leading = myLeadingSpaces(line)


### PR DESCRIPTION
Python2 allows `<int> < None` which evaluates to False. In Python3 this raises an exception. See:
https://crbug.com/1296209

Initializing with 0 preserves the logic and works in both Python versions.